### PR TITLE
nodeのversionの変更と、軽量化

### DIFF
--- a/node-flow/Dockerfile
+++ b/node-flow/Dockerfile
@@ -1,2 +1,5 @@
-FROM node:6.11
-RUN apt-get update -qq && apt-get install -y ocaml libelf-dev
+FROM node:8.17.0-slim
+RUN apt-get update -qq && \
+    apt-get install -y ocaml libelf-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- nodeのバージョンが古すぎるので、8.17にした
- 軽いほうがいいのでslimにした(1.13GB→488MB)