### PR TITLE
postgresでja_JP.UTF-8使えるように(9.3版)

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:9.3
+
+RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8


### PR DESCRIPTION
SSIA